### PR TITLE
添加 repo url 及禁用 google 字体

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,10 @@
 site_name: Celeste Wiki
+repo_url: https://github.com/LuckyBoy-7/CelesteWikiModule
 
 theme:
   name: material
   logo: assets/images/favicon.png
+  font: false
   features:
     - content.code.copy
     - content.tabs.link


### PR DESCRIPTION
google 字体的请求严重拖慢了页面的加载 (足足 40s)
![image](https://github.com/user-attachments/assets/de594e50-84cd-420f-8703-48f25220d308)
